### PR TITLE
Fixed duplication sending issue when triggering a tell response

### DIFF
--- a/lib/Voxa-Dashbot.js
+++ b/lib/Voxa-Dashbot.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const DashbotAnalytics = require('dashbot');
-const debug = require('debug')('voxa:dashbot');
+const lambdaLog = require('lambda-log');
 
 const defaultConfig = {
   ignoreUsers: [],
@@ -30,7 +30,7 @@ function register(skill, config) {
     if (pluginConfig.suppressSending) return Promise.resolve(null);
     if (isSessionEndedRequest && request.request.type !== 'SessionEndedRequest') return Promise.resolve(null);
 
-    debug('Sending to dashbot');
+    lambdaLog.info('Sending to dashbot');
 
     const newRequestObject = _.pick(request, ['version', 'session', 'context', 'request']);
 
@@ -38,18 +38,18 @@ function register(skill, config) {
     return Dashbot.logIncoming(newRequestObject)
       .then(response => response.text())
       .then((response) => {
-        debug('logIncoming response', response);
+        lambdaLog.info('logIncoming response', { response });
 
         // PROCESSING OUTGOING RESPONSE
         return Dashbot.logOutgoing(newRequestObject, reply.toJSON());
       })
       .then(response => response.text())
       .then((response) => {
-        debug('logOutgoing response', response);
+        lambdaLog.info('logOutgoing response', { response });
         return response;
       })
       .catch((err) => {
-        debug('err', err);
+        lambdaLog.error(err);
       });
   }
 }

--- a/lib/Voxa-Dashbot.js
+++ b/lib/Voxa-Dashbot.js
@@ -21,11 +21,14 @@ function register(skill, config) {
   const Dashbot = DashbotAnalytics(pluginConfig.api_key, dashbotConfig).alexa;
 
   skill.onBeforeReplySent(track);
-  skill.onSessionEnded(track);
+  skill.onSessionEnded((request, reply, transition) => {
+    track(request, reply, transition, true);
+  });
 
-  function track(request, reply) {
+  function track(request, reply, transition, isSessionEndedRequest) {
     if (_.includes(pluginConfig.ignoreUsers, request.user.userId)) return Promise.resolve(null);
     if (pluginConfig.suppressSending) return Promise.resolve(null);
+    if (isSessionEndedRequest && request.request.type !== 'SessionEndedRequest') return Promise.resolve(null);
 
     debug('Sending to dashbot');
 
@@ -35,18 +38,27 @@ function register(skill, config) {
     return Dashbot.logIncoming(newRequestObject)
       .then(response => response.text())
       .then((response) => {
-        console.log('Dashbot', 'logIncoming response', response);
+        debug('logIncoming response', response);
+
+        const jsonReply = reply.toJSON();
+
+        if (isSessionEndedRequest && _.isEmpty(jsonReply.response.outputSpeech)) {
+          jsonReply.response.outputSpeech = {
+            type: 'PlainText',
+            ssml: 'SessionEndedRequest',
+          };
+        }
 
         // PROCESSING OUTGOING RESPONSE
-        return Dashbot.logOutgoing(newRequestObject, reply.toJSON());
+        return Dashbot.logOutgoing(newRequestObject, jsonReply);
       })
       .then(response => response.text())
       .then((response) => {
-        console.log('Dashbot', 'logOutgoing response', response);
+        debug('logOutgoing response', response);
         return response;
       })
       .catch((err) => {
-        console.log('voxa-dashbot', 'err', err);
+        debug('err', err);
       });
   }
 }

--- a/lib/Voxa-Dashbot.js
+++ b/lib/Voxa-Dashbot.js
@@ -40,17 +40,8 @@ function register(skill, config) {
       .then((response) => {
         debug('logIncoming response', response);
 
-        const jsonReply = reply.toJSON();
-
-        if (isSessionEndedRequest && _.isEmpty(jsonReply.response.outputSpeech)) {
-          jsonReply.response.outputSpeech = {
-            type: 'PlainText',
-            ssml: 'SessionEndedRequest',
-          };
-        }
-
         // PROCESSING OUTGOING RESPONSE
-        return Dashbot.logOutgoing(newRequestObject, jsonReply);
+        return Dashbot.logOutgoing(newRequestObject, reply.toJSON());
       })
       .then(response => response.text())
       .then((response) => {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "dashbot": "^9.8.0",
+    "dashbot": "^9.9.1",
     "debug": "^2.6.9",
     "lodash": "^4.17.10"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa-dashbot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Integrate Dashbot analytics into your Alexa apps using the voxa framework",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "istanbul cover _mocha -- --recursive tests",
     "test-ci": "JUNIT_REPORT_PATH=junit.xml istanbul cover _mocha -- --recursive --colors --reporter mocha-jenkins-reporter tests",
     "cobertura": "istanbul report cobertura --root coverage",
-    "lint": "eslint --fix lib/ tests/",
-    "lint-fix": "eslint lib/ tests/"
+    "lint": "eslint lib/ tests/",
+    "lint-fix": "eslint --fix lib/ tests/"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "dashbot": "^9.9.1",
-    "debug": "^2.6.9",
+    "lambda-log": "^1.4.0",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/tests/voxa-dashbot.spec.js
+++ b/tests/voxa-dashbot.spec.js
@@ -100,6 +100,39 @@ describe('Voxa-Dashbot plugin', () => {
       });
   });
 
+  it('should register DashbotAnalytics on StopIntent and end the session', () => {
+    const spy = simple.spy(() => ({ reply: 'ExitIntent.GeneralExit' }));
+    voxaStateMachine.onIntent('SomeIntent', spy);
+
+    const event = {
+      request: {
+        type: 'IntentRequest',
+        intent: {
+          name: 'SomeIntent',
+        },
+      },
+      session: {
+        new: false,
+        application: {
+          applicationId: 'appId',
+        },
+        user: {
+          userId: 'user-id',
+        },
+      },
+    };
+
+    voxaDashbot(voxaStateMachine, dashbotConfig);
+    return voxaStateMachine.execute(event)
+      .then((reply) => {
+        expect(spy.called).to.be.true;
+        expect(reply.session.new).to.equal(false);
+        expect(reply.session.attributes.state).to.equal('die');
+        expect(reply.msg.statements).to.have.lengthOf(1);
+        expect(reply.msg.statements[0]).to.equal('Ok. Goodbye.');
+      });
+  });
+
   it('should register DashbotAnalytics on SessionEndedRequest', () => {
     const spy = simple.spy(() => ({ reply: 'ExitIntent.GeneralExit' }));
     voxaStateMachine.onSessionEnded(spy);

--- a/tests/voxa-dashbot.spec.js
+++ b/tests/voxa-dashbot.spec.js
@@ -10,8 +10,6 @@ const voxaDashbot = require('../lib/Voxa-Dashbot');
 const views = require('./views');
 const version = require('../package').dependencies.dashbot.replace('^', '');
 
-console.log('DASHBOT VERSION', version);
-
 const expect = chai.expect;
 const DASHBOT_URL = 'https://tracker.dashbot.io';
 const dashbotConfig = {


### PR DESCRIPTION
This happened when we sent a `tell` response like the common `AMAZON.StopIntent`, the methods:

onBeforeReplySent
onSessionEnded

were both triggered, in that case, Voxa triggered `onSessionEnded` as part of its flow but it was a SessionEndedRequest from Alexa. So, this is why I'm validating when this happens